### PR TITLE
Add ability to query multiple keys at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ For example, given:
 |`$..book[0,1]`, `$..book[:2]`|`json[any: .descendantOrSelf].book[0, 1])`, `json[any: .descendantOrSelf].book[0...1])`, `json[any: .descendantOrSelf].book[0..<2])`|[The first two books.](/Tests/RBBJSONTests/READMETests.swift#L141-L154)|
 |`$..book[?(@.isbn)]`|`json[any: .descendantOrSelf].book[has: \.isbn]`|[All books with an ISBN number.](/Tests/RBBJSONTests/READMETests.swift#L159-L174)|
 |`$..book[?(@.price<10)]`|`json.store.book[matches: { $0.price <= 10 }]`|[All books cheaper than `10`.](/Tests/RBBJSONTests/READMETests.swift#L179-L193)|
+|`$.store["book", "bicycle"]..["price", "author"]`|`json.store["book", "bicycle"][any: .descendantOrSelf]["price", "author"]`|[The author (where available) and price of every book or bicycle.](/Tests/RBBJSONTests/READMETests.swift#L203-L223)|
 
 Once you query a JSON value using one of the higher order selectors, the resulting type of the expression will be a lazy `RBBJSON.Query`:
 

--- a/Sources/RBBJSON/RBBJSON+Query.swift
+++ b/Sources/RBBJSON/RBBJSON+Query.swift
@@ -4,27 +4,21 @@ public extension RBBJSON {
     /// Matches multiple indices on a JSON array. Negative indices can be
     /// used to index from the end.
     subscript(indices: Int...) -> Query {
-        get {
-            Query(json: self).appending(.indices(indices))
-        }
+        Query(json: self).appending(.indices(indices))
     }
 
     /// Matches a range of indices on a JSON array. Negative indices are not
     /// allowed.
     subscript(range: Range<Int>) -> Query {
-        get {
-            precondition(range.lowerBound >= 0, "Range must not have negative indices.")
+        precondition(range.lowerBound >= 0, "Range must not have negative indices.")
 
-            return Query(json: self)[range]
-        }
+        return Query(json: self)[range]
     }
 
     /// Matches a range of indices on a JSON array. Negative indices are not
     /// allowed.
     subscript(range: ClosedRange<Int>) -> Query {
-        get {
-            self[range.lowerBound ..< range.upperBound + 1]
-        }
+        self[range.lowerBound ..< range.upperBound + 1]
     }
 
     /// Matches values on a JSON object or array that the given `predicate`
@@ -94,43 +88,33 @@ public extension RBBJSON {
 
         /// Matches a particular key on a JSON object.
         public subscript(key: String) -> Self {
-            get {
-                appending(.key(key))
-            }
+            appending(.key(key))
         }
 
         /// Matches a particular index on a JSON array. Negative indices can be
         /// used to index from the end.
         public subscript(index: Int) -> Self {
-            get {
-                appending(.indices([index]))
-            }
+            appending(.indices([index]))
         }
 
         /// Matches multiple indices on a JSON array. Negative indices can be
         /// used to index from the end.
         public subscript(indices: Int...) -> Self {
-            get {
-                appending(.indices(indices))
-            }
+            appending(.indices(indices))
         }
 
         /// Matches a range of indices on a JSON array. Negative indices are not
         /// allowed.
         public subscript(range: Range<Int>) -> Self {
-            get {
-                precondition(range.lowerBound >= 0, "Range must not have negative indices.")
+            precondition(range.lowerBound >= 0, "Range must not have negative indices.")
 
-                return appending(.range(range))
-            }
+            return appending(.range(range))
         }
 
         /// Matches a range of indices on a JSON array. Negative indices are not
         /// allowed.
         public subscript(range: ClosedRange<Int>) -> Self {
-            get {
-                self[range.lowerBound ..< range.upperBound + 1]
-            }
+            self[range.lowerBound ..< range.upperBound + 1]
         }
 
         /// Matches a particular key on a JSON object.

--- a/Tests/RBBJSONTests/READMETests.swift
+++ b/Tests/RBBJSONTests/READMETests.swift
@@ -193,6 +193,36 @@ final class READMETests: XCTestCase {
         ])
     }
 
+    func testMultipleKeys() {
+        // JSONPath: $.store["book", "bicycle"]..["price", "author"]
+        //
+        // NOTE: This query doesn't seem to work in Gatling but does in Jayway
+        //       with slightly different semantics: Turning on _Return null for
+        //       missing leaf_ will produce the expected result although with a
+        //       `null` value for the bicycle's author that we're omitting here.
+        RBBAssertEqual(json.store["book", "bicycle"][any: .descendantOrSelf]["price", "author"], [
+            [
+                "price": 19.95,
+            ],
+            [
+                "price": 8.95,
+                "author": "Nigel Rees"
+            ],
+            [
+                "price": 12.99,
+                "author": "Evelyn Waugh"
+            ],
+            [
+                "price": 8.99,
+                "author": "Herman Melville"
+            ],
+            [
+                "price": 22.99,
+                "author": "J. R. R. Tolkien"
+            ],
+        ])
+    }
+
     func testExample() {
         RBBAssertEqual(json.store.book[0].title.compactMap(String.init),    [
             "Sayings of the Century"


### PR DESCRIPTION
Adds the ability to query multiple keys at once, e.g. `json.store["book", "bicycle"][any: .descendantOrSelf]["price", "author"]` results in
```swift
[
    [
        "price": 19.95,
    ],
    [
        "price": 8.95,
        "author": "Nigel Rees"
    ],
    [
        "price": 12.99,
        "author": "Evelyn Waugh"
    ],
    [
        "price": 8.99,
        "author": "Herman Melville"
    ],
    [
        "price": 22.99,
        "author": "J. R. R. Tolkien"
    ],
]
```

Note that there are slightly different semantics for a single key. For a single key, values are flattened into an array whereas for multiple keys, an array of objects with the given keys (where available) is returned. While slightly inconsistent, I think it's closer to what you want and only matters for trailing selectors.

E.g. `json.store["book", "bicycle"][any: .descendantOrSelf]["price"]` results in 

```swift
[19.95, 8.95, 12.99, 8.99, 22.99]
```

but if a single value object is required, you could always use a second bogus key to get single value objects `json.store["book", "bicycle"][any: .descendantOrSelf]["price", "<INVALID>"]` as `null` values are stripped.