### PR TITLE
Make RBBJSON no longer a Sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,13 +105,13 @@ json.store.book[0]["title"]     // RBBJSON.string("Sayings of the Century")
 json.store.book[0, 1]["title"]  // RBBJSON.Query
 ```
 
-Because both `RBBJSON` and `RBBJSON.Query` conform to `Sequence`, you can initialize an `Array` with either to obtain the results or use e.g. `compactMap`:
+Because `RBBJSON.Query` conforms to `Sequence`, you can initialize an `Array` with it to obtain the results or use e.g. `compactMap`:
 
 ```swift
-json.store.book[0].title.compactMap(String.init)     // ["Sayings of the Century"]
-json.store.book[0, 1].title.compactMap(String.init)  // ["Sayings of the Century", "Sword of Honour"]
+String(json.store.book[0].title)                    // "Sayings of the Century"
+json.store.book[0, 1].title.compactMap(String.init) // ["Sayings of the Century", "Sword of Honour"]
 
-json.store.book[0]["invalid Property"].compactMap(String.init)    // []
+String(json.store.book[0]["invalid Property"])                    // nil
 json.store.book[0, 1]["invalid Property"].compactMap(String.init) // []
 ```
 

--- a/Sources/RBBJSON/RBBJSON.swift
+++ b/Sources/RBBJSON/RBBJSON.swift
@@ -170,16 +170,3 @@ extension RBBJSON: CustomDebugStringConvertible {
         }
     }
 }
-
-extension RBBJSON: Sequence {
-    public func makeIterator() -> AnyIterator<RBBJSON> {
-        switch self {
-        case .array(let values):
-            return AnyIterator(values.makeIterator())
-        case .null:
-            return AnyIterator([].makeIterator())
-        default:
-            return AnyIterator(CollectionOfOne(self).makeIterator())
-        }
-    }
-}

--- a/Tests/RBBJSONTests/SequenceTests.swift
+++ b/Tests/RBBJSONTests/SequenceTests.swift
@@ -21,29 +21,5 @@ final class SequenceTests: XCTestCase {
                 XCTAssertEqual(result.string, "Hello World")
             }
         }
-
-        for value in ["a": 123] as RBBJSON {
-            XCTAssert(Double(value.a) ?? 0 >= 0)
-        }
-
-        for value in [1, 2, 3] as RBBJSON {
-            XCTAssert(Double(value) ?? 0 >= 0)
-        }
-
-        for value in 1 as RBBJSON {
-            XCTAssertEqual(Double(value), 1)
-        }
-
-        for value in true as RBBJSON {
-            XCTAssertEqual(Bool(value), true)
-        }
-
-        for value in "test" as RBBJSON {
-            XCTAssertEqual(String(value), "test")
-        }
-
-        for _ in nil as RBBJSON {
-            fatalError()
-        }
     }
 }


### PR DESCRIPTION
I though it would be nice to write `for value in json.array` but it doesn't seem worth the hassle.